### PR TITLE
Fix segfault, bump version, update agent instructions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "deno-printers"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "lazy_static",
  "printers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "deno-printers"
 authors = ["Evan Simkowitz <esimkowitz@users.noreply.github.com>"]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,10 @@ Get the status of a print job by ID.
 
 Remove old completed/failed jobs and return the count removed.
 
+#### `shutdown(): void`
+
+Shutdown the library and cleanup all background threads. This function is automatically called on process exit, but can be manually invoked if needed.
+
 ### Classes
 
 #### `Printer`
@@ -354,6 +358,25 @@ through JavaScript's FinalizationRegistry:
   disposed instances throws descriptive errors
 - **No memory leaks**: The FinalizationRegistry ensures native resources are
   always cleaned up
+
+### Thread Management & Process Safety
+
+The library includes robust thread management to prevent segmentation faults and ensure clean shutdown:
+
+- **Background Thread Management**: Print job monitoring runs in background threads that are properly tracked and cleaned up
+- **Automatic Shutdown**: The library automatically handles cleanup on process exit, browser unload events, and common process signals (SIGINT, SIGTERM, etc.)
+- **Manual Shutdown**: Call `shutdown()` explicitly if you need to clean up resources before process exit
+- **Timeout Protection**: Shutdown operations have a 5-second timeout to prevent hanging
+- **Thread Safety**: All shared resources are protected with appropriate synchronization primitives
+
+```typescript
+import { shutdown } from "@esimkowitz/printers";
+
+// Manual cleanup (optional - automatic cleanup is provided)
+shutdown();
+```
+
+The library's shutdown mechanism ensures that all background threads are properly terminated and resources are cleaned up, preventing common issues like segmentation faults that can occur with FFI libraries.
 
 ### Printer Properties
 

--- a/README.md
+++ b/README.md
@@ -385,14 +385,6 @@ The native library is built as a C dynamic library (cdylib) and loaded via
 Deno's FFI capabilities, providing near-native performance for printer
 operations while maintaining memory safety.
 
-## Contributing
-
-This library is built with:
-
-- **Rust** - Native library with printer operations
-- **Deno** - TypeScript runtime and FFI host
-- **GitHub Actions** - CI/CD with multi-platform builds
-
 ## License
 
 MIT License - see LICENSE file for details.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # @esimkowitz/printers
 
+[![JSR](https://jsr.io/badges/@esimkowitz/printers)](https://jsr.io/@<scope>/<package>)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Build](https://github.com/esimkowitz/deno-printers/actions/workflows/ci.yml/badge.svg)](https://github.com/esimkowitz/deno-printers/actions/workflows/ci.yml)
+[![Release](https://github.com/esimkowitz/deno-printers/actions/workflows/release.yml/badge.svg)](https://github.com/esimkowitz/deno-printers/actions/workflows/release.yml)
+
 A cross-platform Deno library for interacting with system printers via FFI to a
 native Rust library.
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ Remove old completed/failed jobs and return the count removed.
 
 #### `shutdown(): void`
 
-Shutdown the library and cleanup all background threads. This function is automatically called on process exit, but can be manually invoked if needed.
+Shutdown the library and cleanup all background threads. This function is
+automatically called on process exit, but can be manually invoked if needed.
 
 ### Classes
 
@@ -361,13 +362,20 @@ through JavaScript's FinalizationRegistry:
 
 ### Thread Management & Process Safety
 
-The library includes robust thread management to prevent segmentation faults and ensure clean shutdown:
+The library includes robust thread management to prevent segmentation faults and
+ensure clean shutdown:
 
-- **Background Thread Management**: Print job monitoring runs in background threads that are properly tracked and cleaned up
-- **Automatic Shutdown**: The library automatically handles cleanup on process exit, browser unload events, and common process signals (SIGINT, SIGTERM, etc.)
-- **Manual Shutdown**: Call `shutdown()` explicitly if you need to clean up resources before process exit
-- **Timeout Protection**: Shutdown operations have a 5-second timeout to prevent hanging
-- **Thread Safety**: All shared resources are protected with appropriate synchronization primitives
+- **Background Thread Management**: Print job monitoring runs in background
+  threads that are properly tracked and cleaned up
+- **Automatic Shutdown**: The library automatically handles cleanup on process
+  exit, browser unload events, and common process signals (SIGINT, SIGTERM,
+  etc.)
+- **Manual Shutdown**: Call `shutdown()` explicitly if you need to clean up
+  resources before process exit
+- **Timeout Protection**: Shutdown operations have a 5-second timeout to prevent
+  hanging
+- **Thread Safety**: All shared resources are protected with appropriate
+  synchronization primitives
 
 ```typescript
 import { shutdown } from "@esimkowitz/printers";
@@ -376,7 +384,9 @@ import { shutdown } from "@esimkowitz/printers";
 shutdown();
 ```
 
-The library's shutdown mechanism ensures that all background threads are properly terminated and resources are cleaned up, preventing common issues like segmentation faults that can occur with FFI libraries.
+The library's shutdown mechanism ensures that all background threads are
+properly terminated and resources are cleaned up, preventing common issues like
+segmentation faults that can occur with FFI libraries.
 
 ### Printer Properties
 

--- a/deno.json
+++ b/deno.json
@@ -67,7 +67,8 @@
       ".git/",
       ".github/",
       "reports/",
-      "coverage/"
+      "coverage/",
+      "scripts/"
     ]
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -31,7 +31,8 @@
   },
   "imports": {
     "@std/assert": "jsr:@std/assert@1",
-    "@std/path": "jsr:@std/path@1"
+    "@std/path": "jsr:@std/path@1",
+    "@std/semver": "jsr:@std/semver@1"
   },
   "fmt": {
     "exclude": [

--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@esimkowitz/printers",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Cross-platform Deno library for interacting with system printers via FFI to native Rust library",
   "license": "MIT",
   "repository": {
@@ -21,7 +21,10 @@
     "test": "deno test --allow-ffi --unstable-ffi --allow-env mod.test.ts",
     "test:real": "deno test --allow-ffi --unstable-ffi --allow-env mod.test.ts",
     "test:doc": "deno test --doc --allow-ffi --unstable-ffi --allow-env mod.ts",
-    "build": "cargo build --release"
+    "build": "cargo build --release",
+    "bump:patch": "deno run --allow-read --allow-write scripts/bump-version.ts patch",
+    "bump:minor": "deno run --allow-read --allow-write scripts/bump-version.ts minor",
+    "bump:major": "deno run --allow-read --allow-write scripts/bump-version.ts major"
   },
   "exports": {
     ".": "./mod.ts"

--- a/deno.lock
+++ b/deno.lock
@@ -4,7 +4,8 @@
     "jsr:@std/assert@1": "1.0.13",
     "jsr:@std/internal@^1.0.6": "1.0.10",
     "jsr:@std/internal@^1.0.9": "1.0.10",
-    "jsr:@std/path@1": "1.1.1"
+    "jsr:@std/path@1": "1.1.1",
+    "jsr:@std/semver@1": "1.0.5"
   },
   "jsr": {
     "@std/assert@1.0.13": {
@@ -21,12 +22,16 @@
       "dependencies": [
         "jsr:@std/internal@^1.0.9"
       ]
+    },
+    "@std/semver@1.0.5": {
+      "integrity": "529f79e83705714c105ad0ba55bec0f9da0f24d2f726b6cc1c15e505cc2c0624"
     }
   },
   "workspace": {
     "dependencies": [
       "jsr:@std/assert@1",
-      "jsr:@std/path@1"
+      "jsr:@std/path@1",
+      "jsr:@std/semver@1"
     ]
   }
 }

--- a/mod.ts
+++ b/mod.ts
@@ -233,11 +233,11 @@ function setupCleanupHandlers(): void {
     on?: (signal: string, callback: () => void) => void;
     exit: (code?: number) => never;
   }
-  
+
   const globalWithProcess = globalThis as typeof globalThis & {
     process?: NodeProcess;
   };
-  
+
   if (typeof globalWithProcess.process !== "undefined") {
     const process = globalWithProcess.process;
     ["SIGINT", "SIGTERM", "SIGQUIT"].forEach((signal) => {

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -1,0 +1,140 @@
+#!/usr/bin/env deno run --allow-read --allow-write
+/**
+ * Version bump utility script
+ * Updates version in both deno.json and Cargo.toml
+ * 
+ * Usage:
+ *   deno run --allow-read --allow-write scripts/bump-version.ts <type>
+ *   where <type> is: major, minor, or patch
+ */
+
+import { join } from "@std/path";
+
+interface SemanticVersion {
+  major: number;
+  minor: number;
+  patch: number;
+}
+
+type BumpType = "major" | "minor" | "patch";
+
+function parseVersion(version: string): SemanticVersion {
+  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!match) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+  
+  return {
+    major: parseInt(match[1], 10),
+    minor: parseInt(match[2], 10),
+    patch: parseInt(match[3], 10),
+  };
+}
+
+function bumpVersion(version: SemanticVersion, type: BumpType): SemanticVersion {
+  const newVersion = { ...version };
+  
+  switch (type) {
+    case "major":
+      newVersion.major++;
+      newVersion.minor = 0;
+      newVersion.patch = 0;
+      break;
+    case "minor":
+      newVersion.minor++;
+      newVersion.patch = 0;
+      break;
+    case "patch":
+      newVersion.patch++;
+      break;
+    default:
+      throw new Error(`Invalid bump type: ${type}`);
+  }
+  
+  return newVersion;
+}
+
+function formatVersion(version: SemanticVersion): string {
+  return `${version.major}.${version.minor}.${version.patch}`;
+}
+
+async function updateDenoJson(newVersion: string): Promise<void> {
+  const denoJsonPath = join(Deno.cwd(), "deno.json");
+  const content = await Deno.readTextFile(denoJsonPath);
+  const config = JSON.parse(content);
+  
+  config.version = newVersion;
+  
+  await Deno.writeTextFile(denoJsonPath, JSON.stringify(config, null, 2) + "\n");
+}
+
+async function updateCargoToml(newVersion: string): Promise<void> {
+  const cargoTomlPath = join(Deno.cwd(), "Cargo.toml");
+  const content = await Deno.readTextFile(cargoTomlPath);
+  
+  const updatedContent = content.replace(
+    /^version = "[\d.]+"/m,
+    `version = "${newVersion}"`
+  );
+  
+  await Deno.writeTextFile(cargoTomlPath, updatedContent);
+}
+
+async function getCurrentVersion(): Promise<string> {
+  const denoJsonPath = join(Deno.cwd(), "deno.json");
+  const content = await Deno.readTextFile(denoJsonPath);
+  const config = JSON.parse(content);
+  return config.version;
+}
+
+function showUsage(): void {
+  console.log("Usage: deno run --allow-read --allow-write scripts/bump-version.ts <type>");
+  console.log("  where <type> is one of: major, minor, patch");
+  console.log("");
+  console.log("Examples:");
+  console.log("  deno task bump:patch   # 0.1.3 -> 0.1.4");
+  console.log("  deno task bump:minor   # 0.1.3 -> 0.2.0");
+  console.log("  deno task bump:major   # 0.1.3 -> 1.0.0");
+}
+
+async function main(): Promise<void> {
+  const args = Deno.args;
+  
+  if (args.length !== 1 || !["major", "minor", "patch"].includes(args[0])) {
+    showUsage();
+    Deno.exit(1);
+  }
+  
+  const bumpType = args[0] as BumpType;
+  
+  try {
+    // Get current version
+    const currentVersionString = await getCurrentVersion();
+    const currentVersion = parseVersion(currentVersionString);
+    
+    console.log(`Current version: ${currentVersionString}`);
+    
+    // Calculate new version
+    const newVersion = bumpVersion(currentVersion, bumpType);
+    const newVersionString = formatVersion(newVersion);
+    
+    console.log(`New version: ${newVersionString}`);
+    
+    // Update files
+    console.log("Updating deno.json...");
+    await updateDenoJson(newVersionString);
+    
+    console.log("Updating Cargo.toml...");
+    await updateCargoToml(newVersionString);
+    
+    console.log(`✅ Successfully bumped ${bumpType} version to ${newVersionString}`);
+    
+  } catch (error) {
+    console.error(`❌ Error: ${error.message}`);
+    Deno.exit(1);
+  }
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/scripts/bump-version.ts
+++ b/scripts/bump-version.ts
@@ -2,81 +2,39 @@
 /**
  * Version bump utility script
  * Updates version in both deno.json and Cargo.toml
- * 
+ *
  * Usage:
  *   deno run --allow-read --allow-write scripts/bump-version.ts <type>
  *   where <type> is: major, minor, or patch
  */
 
 import { join } from "@std/path";
-
-interface SemanticVersion {
-  major: number;
-  minor: number;
-  patch: number;
-}
+import { format, increment, parse } from "@std/semver";
 
 type BumpType = "major" | "minor" | "patch";
-
-function parseVersion(version: string): SemanticVersion {
-  const match = version.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!match) {
-    throw new Error(`Invalid version format: ${version}`);
-  }
-  
-  return {
-    major: parseInt(match[1], 10),
-    minor: parseInt(match[2], 10),
-    patch: parseInt(match[3], 10),
-  };
-}
-
-function bumpVersion(version: SemanticVersion, type: BumpType): SemanticVersion {
-  const newVersion = { ...version };
-  
-  switch (type) {
-    case "major":
-      newVersion.major++;
-      newVersion.minor = 0;
-      newVersion.patch = 0;
-      break;
-    case "minor":
-      newVersion.minor++;
-      newVersion.patch = 0;
-      break;
-    case "patch":
-      newVersion.patch++;
-      break;
-    default:
-      throw new Error(`Invalid bump type: ${type}`);
-  }
-  
-  return newVersion;
-}
-
-function formatVersion(version: SemanticVersion): string {
-  return `${version.major}.${version.minor}.${version.patch}`;
-}
 
 async function updateDenoJson(newVersion: string): Promise<void> {
   const denoJsonPath = join(Deno.cwd(), "deno.json");
   const content = await Deno.readTextFile(denoJsonPath);
   const config = JSON.parse(content);
-  
+
   config.version = newVersion;
-  
-  await Deno.writeTextFile(denoJsonPath, JSON.stringify(config, null, 2) + "\n");
+
+  await Deno.writeTextFile(
+    denoJsonPath,
+    JSON.stringify(config, null, 2) + "\n",
+  );
 }
 
 async function updateCargoToml(newVersion: string): Promise<void> {
   const cargoTomlPath = join(Deno.cwd(), "Cargo.toml");
   const content = await Deno.readTextFile(cargoTomlPath);
-  
+
   const updatedContent = content.replace(
     /^version = "[\d.]+"/m,
-    `version = "${newVersion}"`
+    `version = "${newVersion}"`,
   );
-  
+
   await Deno.writeTextFile(cargoTomlPath, updatedContent);
 }
 
@@ -88,7 +46,9 @@ async function getCurrentVersion(): Promise<string> {
 }
 
 function showUsage(): void {
-  console.log("Usage: deno run --allow-read --allow-write scripts/bump-version.ts <type>");
+  console.log(
+    "Usage: deno run --allow-read --allow-write scripts/bump-version.ts <type>",
+  );
   console.log("  where <type> is one of: major, minor, patch");
   console.log("");
   console.log("Examples:");
@@ -99,38 +59,45 @@ function showUsage(): void {
 
 async function main(): Promise<void> {
   const args = Deno.args;
-  
+
   if (args.length !== 1 || !["major", "minor", "patch"].includes(args[0])) {
     showUsage();
     Deno.exit(1);
   }
-  
+
   const bumpType = args[0] as BumpType;
-  
+
   try {
     // Get current version
     const currentVersionString = await getCurrentVersion();
-    const currentVersion = parseVersion(currentVersionString);
-    
+    const currentVersion = parse(currentVersionString);
+
+    if (!currentVersion) {
+      throw new Error(`Invalid version format: ${currentVersionString}`);
+    }
+
     console.log(`Current version: ${currentVersionString}`);
-    
-    // Calculate new version
-    const newVersion = bumpVersion(currentVersion, bumpType);
-    const newVersionString = formatVersion(newVersion);
-    
+
+    // Calculate new version using semver library
+    const newVersion = increment(currentVersion, bumpType);
+    const newVersionString = format(newVersion);
+
     console.log(`New version: ${newVersionString}`);
-    
+
     // Update files
     console.log("Updating deno.json...");
     await updateDenoJson(newVersionString);
-    
+
     console.log("Updating Cargo.toml...");
     await updateCargoToml(newVersionString);
-    
-    console.log(`✅ Successfully bumped ${bumpType} version to ${newVersionString}`);
-    
+
+    console.log(
+      `✅ Successfully bumped ${bumpType} version to ${newVersionString}`,
+    );
   } catch (error) {
-    console.error(`❌ Error: ${error.message}`);
+    console.error(
+      `❌ Error: ${error instanceof Error ? error.message : String(error)}`,
+    );
     Deno.exit(1);
   }
 }


### PR DESCRIPTION
This pull request introduces several important improvements to version management, thread and memory safety, and developer experience for the `@esimkowitz/printers` Deno/Rust library. The most significant changes are the addition of a robust version bumping utility, comprehensive thread shutdown and cleanup mechanisms to prevent segfaults, and enhanced documentation and metadata. These updates improve both the reliability of the library and the workflow for contributors.

**Versioning and Developer Tooling:**
- Added a version bump utility script (`scripts/bump-version.ts`) that updates both `deno.json` and `Cargo.toml` using semantic versioning, with new Deno tasks to automate patch, minor, and major version bumps. [[1]](diffhunk://#diff-d7c10983349f520dd101e4bcb29702f993cf43b625cc0128be48eb8f80282957R1-R107) [[2]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL24-R35) [[3]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R128-R213)
- Updated project version to `0.1.4` in both `deno.json` and `Cargo.toml`. [[1]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L4-R4)

**Thread Management and Memory Safety:**
- Implemented a shutdown mechanism in Rust: new `shutdown_library()` function signals all background threads to stop, waits for completion (with a 5-second timeout), and cleans up resources to prevent segfaults on process exit. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R73-R74) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R179-R181) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R255-R265) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R313-R318) [[5]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759R454-R482)
- Exposed a `shutdown()` function in TypeScript (`mod.ts`) and set up automatic cleanup on process exit, browser unload, and process signals. Manual shutdown is also supported. [[1]](diffhunk://#diff-e8c3622ccfbed67f4b3058cd4417bf41d066236f49c6f3e63b7c243b584c6734R202-R254) [[2]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R128-R213)

**Documentation and Metadata:**
- Added badges (JSR, License, Build, Release) to the `README.md` for improved visibility and project status.
- Expanded documentation in `CLAUDE.md` and `README.md` to describe new versioning and shutdown features, and removed outdated contribution notes. [[1]](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R128-R213) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-L390)

**Configuration and Testing:**
- Updated `deno.json` to include the new version bump tasks, add the `@std/semver` dependency, and exclude the `scripts/` directory from formatting. [[1]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL24-R35) [[2]](diffhunk://#diff-54337bcff4b919f6b8b4e0b0e51d06fd9124562fde88899be726c24b7e354b7cL66-R71)
- Improved testing reliability by ensuring background threads are properly terminated after tests, as documented in `CLAUDE.md`.

These changes collectively make the library safer, easier to maintain, and more user-friendly for both developers and end-users.